### PR TITLE
Tray visibility (windows)

### DIFF
--- a/src/plugins/platforms/windows/qwindowssystemtrayicon.cpp
+++ b/src/plugins/platforms/windows/qwindowssystemtrayicon.cpp
@@ -108,8 +108,8 @@ static void setIconContents(NOTIFYICONDATA &tnd, const QString &tip, HICON hIcon
 static void setIconVisibility(NOTIFYICONDATA &tnd, bool v)
 {
     tnd.uFlags |= NIF_STATE;
-    tnd.dwStateMask = NIS_HIDDEN;
     tnd.dwState = v ? 0 : NIS_HIDDEN;
+    tnd.dwStateMask = NIS_HIDDEN;
 }
 
 // Match the HWND of the dummy window to the instances


### PR DESCRIPTION
The `dwState` and `dwStateMask` are otherway around.   It causes windows application using the tray (notification area) to be hidden every time it starts.

`dwStateMask` must be below `dwState` as to quote: "A value that specifies which bits of the dwState member are retrieved or modified."

Based on the MSDN

```
dwState
Type: DWORD

Windows 2000 and later. The state of the icon. One or both of the following values:
NIS_HIDDEN (0x00000001)
0x00000001. The icon is hidden.
NIS_SHAREDICON (0x00000002)
0x00000002. The icon resource is shared between multiple icons.

dwStateMask
Type: DWORD

Windows 2000 and later. A value that specifies which bits of the dwState member are retrieved or modified. The possible values are the same as those for dwState. For example, setting this member to NIS_HIDDEN causes only the item's hidden state to be modified while the icon sharing bit is ignored regardless of its value.